### PR TITLE
chore: Update nixpkgs pin

### DIFF
--- a/artifact-post-action/tools/nixpkgs-pin.json
+++ b/artifact-post-action/tools/nixpkgs-pin.json
@@ -1,12 +1,11 @@
 {
-    "url": "https://github.com/NixOS/nixpkgs.git",
-    "rev": "e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d",
-    "date": "2023-12-11T06:36:02+01:00",
-    "path": "/nix/store/j8fj8fx1shw8481s284wgm2kgappivm5-nixpkgs",
-    "sha256": "114ggf0xbwq16djg4qql3jljknk9xr8h7dw18ccalwqg9k1cgv0g",
-    "fetchLFS": false,
-    "fetchSubmodules": false,
-    "deepClone": false,
-    "leaveDotGit": false
-  }
-  
+  "url": "https://github.com/NixOS/nixpkgs.git",
+  "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
+  "date": "2024-04-22T17:05:09+00:00",
+  "path": "/nix/store/3j6rfjbjw6mcil8a8svbjwrhq254rzzw-nixpkgs",
+  "sha256": "1nmra8aiiazi0w19x4cbb3qzy3l6ff9yaki3pkibhwh2grm88132",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/artifact-post-action/tools/oxalica-rust-overlay-pin.json
+++ b/artifact-post-action/tools/oxalica-rust-overlay-pin.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/oxalica/rust-overlay.git",
-  "rev": "d6a1d8f80dbcda4c13993b859a3574c3dde61072",
-  "date": "2023-12-14T02:15:51+00:00",
-  "path": "/nix/store/vpcrxc52qpsi2j587285y8y5flmdpx42-rust-overlay",
-  "sha256": "1mgf2alrarhl21ixmrpgx189hc04qifz2lyiz4b0g1kvqfi5c4lg",
+  "rev": "9a2a11479b94afaf1ecc46384b27abda0d3d5f9d",
+  "date": "2024-04-25T02:14:08+00:00",
+  "path": "/nix/store/h2k8swrk6c03dizxinf504x7ynhxanwi-rust-overlay",
+  "sha256": "17fliqb4ps04ry6qwfamibw1x1j5qy44923vlf09s9srxhh3vadw",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
Use the same pins than in the Tuleap main repo.

Part of request #37907 Update dev/build environment [W17 2024]